### PR TITLE
Support Cyrillic Output

### DIFF
--- a/bulk-llm-translator/.gitignore
+++ b/bulk-llm-translator/.gitignore
@@ -4,3 +4,4 @@ inputs/**
 .DS_Store
 *.zip
 keys.env
+our-env/

--- a/bulk-llm-translator/translate.py
+++ b/bulk-llm-translator/translate.py
@@ -99,7 +99,7 @@ async def execute_provider_pipeline(llm_pipeline):
             print(f"% Finished {provider} tasks in {time.strftime('%H:%M:%S', time.gmtime(time.time() - start_time))}")
 
         # Write to file.
-        with open(out_file, "w") as f:
+        with open(out_file, "w", encoding="utf-8", errors="replace") as f:
             for block in sentences_out:
                 for s in block:
                     f.write(s + "\n")


### PR DESCRIPTION
In testing the code with the test case, I found that my setup did not (natively) support the Cyrillic alphabet, so I changed the output file code to force UTF-8, which does support it. With this change, the code ran perfectly.

(I also added 'our-env/' to the .gitignore, to avoid pushing virtual environment files to the repo)